### PR TITLE
01-accessing-data.ipynb added how-to-run section, fixed typos, other …

### DIFF
--- a/tier_2/data_handling/01-accessing-data.ipynb
+++ b/tier_2/data_handling/01-accessing-data.ipynb
@@ -15,9 +15,50 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## How to run this exercise\n",
+    "\n",
+    "This exercise is in the form of a [Jupyter notebook](https://jupyter.org/). It can be \"run\" in a number of free cloud based environments (see three options below). These require no installation. When you click on one of the links below ([`Open in Colab`](https://colab.research.google.com/github/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb), [`Open in Kaggle`](https://kaggle.com/kernels/welcome?src=https://github.com/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb) or [`Launch in Deepnote`](https://deepnote.com/launch?url=https://github.com/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb)) you will be prompted to create a free account, after which you will see the same page you see here. You can run each block of code by selecting shift+control repeatedly, or by selecting the \"play\" icon. \n",
+    "\n",
+    "Advanced users may wish to run this exercise on their own computers by first installing [Python](https://www.python.org/downloads/), [Jupyter](https://jupyter.org/install) and [CliMetLab](https://climetlab.readthedocs.io/en/latest/installing.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<style>\n",
+    "td, th {\n",
+    "   border: 1px solid white;\n",
+    "   border-collapse: collapse;\n",
+    "}\n",
+    "</style>\n",
+    "<table align=\"left\">\n",
+    "  <tr>\n",
+    "    <th>Run the tutorial via free cloud platforms: </th>\n",
+    "    <th><a href=\"https://colab.research.google.com/github/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb\">\n",
+    "        <img src = \"https://colab.research.google.com/assets/colab-badge.svg\" alt = \"Colab\"></th>\n",
+    "    <th><a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb\">\n",
+    "        <img src = \"https://kaggle.com/static/images/open-in-kaggle.svg\" alt = \"Kaggle\"></th>\n",
+    "    <th><a href=\"https://deepnote.com/launch?url=https://github.com/ecmwf-projects/mooc-machine-learning-weather-climate/blob/main/tier_2/data_handling/01-accessing-data.ipynb\">\n",
+    "        <img src = \"https://deepnote.com/buttons/launch-in-deepnote-small.svg\" alt = \"Kaggle\"></th>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that to use Kaggle, you need to enable an option on the notebook. Please follow the instructions here to do this https://stackoverflow.com/questions/68142524/cannot-access-internet-on-kaggle-notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Loading various sources\n",
     "\n",
-    "A source is a \"something providing data\". It needs some parameters to define the actual location of the data. For instance, a source and be a URL, a remote or local server, a database, or a file, etc.\n",
+    "Now let's begin exploring data with CliMetLab. We will start by loading various \"sources\". A source is a \"something providing data\". It needs some parameters to define the actual location of the data. For instance, a source can be a URL, a remote or local server, a database, or a file, etc.\n",
     "\n",
     "Below are a few examples of using ``cml.load_source()``.\n",
     "\n",
@@ -31,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's download a some files for the examples:\n"
+    "Let's download some files for the examples:"
    ]
   },
   {
@@ -46,12 +87,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install and import CliMetLab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install climetlab"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "import climetlab as cml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read data"
    ]
   },
   {
@@ -125,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The purpose of the \"file\" source is to open **any** file, CliMetLab guess what type of file is provided."
+    "The purpose of the \"file\" source is to open **any** file, CliMetLab guesses what type of file is provided."
    ]
   },
   {
@@ -278,14 +342,14 @@
     "- The name is a string that uniquely identifies the dataset.\n",
     "- The argument(s) arg1 and keyword argument(s) arg2 can be used to specify a subset of the dataset.\n",
     "- The data can be accessed using methods such as to_xarray() or to_pandas() or other.\n",
-    "- Relevant metadata are attached directly to the dataset to provides additional information such as an URL, a citation, licence, etc."
+    "- Relevant metadata are attached directly to the dataset to provide additional information such as a URL, a citation, licence, etc."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Example dataset: huriccane database"
+    "### Example dataset: hurricane database"
    ]
   },
   {
@@ -372,7 +436,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "Additionnal datasets are defined with python plugins (via pip install), more details on this process in the \"Dataset plugins\" notebook.\n",
+    "Additional datasets are defined with python plugins (via pip install), more details on this process in the \"Dataset plugins\" notebook.\n",
     "\n",
     "More  examples can be found at (https://climetlab.readthedocs.io/en/latest/examples.html)."
    ]
@@ -435,7 +499,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.12 ('dev2')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -449,7 +513,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12 | packaged by conda-forge | (default, Oct 12 2021, 21:59:51) \n[GCC 9.4.0]"
+   "version": "3.9.7"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Just small edits to the 01-accessing-data.ipynb notebook in the Tier_2 / data_handling directory. I added a section on "How to run this exercise", corrected some typos, and made a few small corrections to the markdown. I also added a line to install CliMetLab.

The notebook works up until the "Example dataset: part of ERA5" heading. The first cell in that section yields an error (it seems to think the data is from the future, and not from 1979 to 1981).